### PR TITLE
Latex sandbox

### DIFF
--- a/sandboxes/latex/Dockerfile
+++ b/sandboxes/latex/Dockerfile
@@ -1,0 +1,11 @@
+FROM blang/latex:ubuntu
+
+COPY convert.sh /usr/local/bin/convert.sh
+
+RUN adduser --home /sandbox --disabled-password sandbox \
+    && chown -R sandbox /sandbox \
+    && chmod +x /usr/local/bin/convert.sh
+
+USER sandbox
+WORKDIR /sandbox
+VOLUME ["/sandbox"]

--- a/sandboxes/latex/box.json
+++ b/sandboxes/latex/box.json
@@ -1,0 +1,4 @@
+{    
+    "image": "codapi/latex",
+    "tmpfs": ["/tmp:rw,size=1024m"]
+}

--- a/sandboxes/latex/build.sh
+++ b/sandboxes/latex/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+name=latex
+title=Latex
+
+echo "Building $title image..."
+docker build --file ./Dockerfile --tag codapi/$name:latest .
+echo "Done"
+
+cat << EOF
+$title image: codapi/$name:latest
+No additional setup is required.
+EOF

--- a/sandboxes/latex/commands.json
+++ b/sandboxes/latex/commands.json
@@ -1,0 +1,14 @@
+{
+    "run": {
+        "engine": "docker",
+        "entry": "in.tex",
+        "steps": [
+            {
+                "box": "latex",
+                "command": ["convert.sh"],
+		        "timeout": 10,
+                "noutput": 65536
+            }
+        ]
+    }
+}

--- a/sandboxes/latex/convert.sh
+++ b/sandboxes/latex/convert.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Prevent LaTeX from reading/writing files in parent directories
+echo 'openout_any = p\nopenin_any = p' > /tmp/texmf.cnf
+TEXMFCNF='/tmp:'
+
+echo "\\documentclass[12pt]{article}
+\\usepackage{amsmath}
+\\usepackage{amssymb}
+\\usepackage{amsfonts}
+\\usepackage{xcolor}
+\\usepackage{siunitx}
+\\usepackage[utf8]{inputenc}
+\\thispagestyle{empty}
+\\begin{document}
+\\begin{math}
+$(cat in.tex)\
+\\end{math}
+\\end{document}" > /tmp/equation.tex
+
+# Compile .tex file to .dvi file. Timeout kills it after 5 seconds if held up
+timeout 5 latex -no-shell-escape -interaction=nonstopmode -halt-on-error -output-directory=/tmp /tmp/equation.tex > /tmp/convert.log 2>&1
+if [ $? -ne 0 ]; then 
+    cat /tmp/convert.log
+    exit 1
+fi
+
+# Convert .dvi to .svg file. Timeout kills it after 5 seconds if held up
+if [ -z ${OUTPUT_SCALE+x} ]; then OUTPUT_SCALE='1.0'; fi
+timeout 5 dvisvgm --no-fonts --scale=$OUTPUT_SCALE --exact -v 0 -o /tmp/equation.svg /tmp/equation.dvi
+if [ $? -ne 0 ]; then 
+    exit 1
+fi
+
+cat /tmp/equation.svg


### PR DESCRIPTION
I have created this sandbox to render several complex formulas and data iterations for a blog post series. The files were updated and adapted to match the structure and naming convention from the repo.

**Example**
Source 
```latex
$
\begin{align*}
    x&=\sqrt{m} \\
    x^2&=m \\
    x^2-m&=0 \\
    f(x)&=x^2-m
\end{align*}
$
```
cURL call
```shell
# as svg
$ curl -s 'http://localhost:1313/v1/exec' \
  -H 'content-type: application/json' \
  --data-raw '{"sandbox":"latex","version":"","command":"run","files":{"":"$\n\\begin{align*}\n    x&=\\sqrt{m} \\\\\n    x^2&=m \\\\\n    x^2-m&=0 \\\\\n    f(x)&=x^2-m\n\\end{align*}\n$"}}' \
| jq -r '.stdout' > latex.svg

# as png, using rsvg-convert from librsvg
$ curl -s 'http://localhost:1313/v1/exec' \
  -H 'content-type: application/json' \
  --data-raw '{"sandbox":"latex","version":"","command":"run","files":{"":"$\n\\begin{align*}\n    x&=\\sqrt{m} \\\\\n    x^2&=m \\\\\n    x^2-m&=0 \\\\\n    f(x)&=x^2-m\n\\end{align*}\n$"}}' \
| jq -r '.stdout' | rsvg-convert -o latex.png -
```
Output
<img width="114" alt="Screenshot 2025-06-07 at 7 40 03 PM" src="https://github.com/user-attachments/assets/68be9e15-dc4a-45fa-a685-3edd12272867" />

Screenshots from my test UI:
<img width="528" alt="Screenshot 2025-05-27 at 9 36 45 PM" src="https://github.com/user-attachments/assets/aa35fbc4-42bd-4511-a6c1-1f1ccabb0883" />
<img width="448" alt="Screenshot 2025-05-27 at 10 25 08 PM" src="https://github.com/user-attachments/assets/2a5d3e8a-1b0f-417f-98cf-2e603443668b" />
